### PR TITLE
Change ordering of fields in typst.toml (discussion would be useful)

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -1,11 +1,24 @@
+# for a description of available keys, see https://github.com/typst/packages/?tab=readme-ov-file#package-format
+
 [package]
 name = ""
 version = "0.1.0"
 entrypoint = "src/lib.typ"
-authors = [""]
-keywords = [""]
+authors = []
 license = "Unlicense"
-repository = ""
 description = ""
-exclude = ["README.md", "CHANGELOG.md", "Justfile", "docs"]
+homepage = ""
+repository = ""
+keywords = []
 categories = []
+disciplines = []
+compiler = ""
+exclude = ["README.md", "CHANGELOG.md", "Justfile", "docs"]
+
+# [template]
+# path = "template"
+# entrypoint = "main.typ"
+# thumbnail = "thumbnail.png"
+
+# [tool.mytool]
+# foo = "bar"


### PR DESCRIPTION
The current `typst.toml` is missing some optional fields and IMO also orders them in a strange way (for example, there are four keys between `keywords` and `categories`, which are both about discoverability of packages via tag-like classifications). This PR changes the order to reflect what's described in [typst/packages](https://github.com/typst/packages/?tab=readme-ov-file#package-format). It also links that page in the file for reference.

Although the order in the packages repo is a minimally opinionated default, I could also imagine some tweaks. Personally, I have the following comments:
- note that the first three are absolutely required and the first six are required for Universe, so that biases the ordering in the packages repo a bit: if you use the less-required fields, maybe you'd consider them more fitting at an earlier place.
- I'd put `description` earlier, somewhere between `name` and `license`
- I'd put `compiler` directly after `entrypoint`
- `homepage` is relatively rare, so I could imagine commenting it out by default
- I like `exclude` being last, it feels the least informative to a reader
- the `[template]` could be removed, but the example contains useful defaults so I think it's worth keeping
- `[tool.mytool]` could be removed or replaced by `[tool.typst-test]` - then it's a useful default and an example at the same time