### PR TITLE
Add commands for packaging and local install/uninstall

### DIFF
--- a/.typstignore
+++ b/.typstignore
@@ -1,0 +1,16 @@
+# this is not a "standard" ignore file, it's specific to this template's `scripts/package` script
+# list any files here that should not be uploaded to Universe when releasing this package
+
+# if you are used to ignore files, be aware that .typstignore is a bit more limited:
+# - only this file is used; .typstignore files in subdirectories are not considered
+# - patterns must match file/directory names from the beginning: `x.typ` will not match `src/x.typ`
+# - `*` in patterns works, but also matches directory separators: `*.typ` _will_ match `src/x.typ`
+# .git and .typstignore are excluded automatically
+
+.github
+scripts
+tests
+Justfile
+# PDF manuals should be included so that they can be linked, but not their sources
+docs/*
+!docs/*.pdf

--- a/Justfile
+++ b/Justfile
@@ -28,5 +28,15 @@ install: (package "@local")
 # install the library with the "@preview" prefix (for pre-release testing)
 install-preview: (package "@preview")
 
+[private]
+remove target:
+  ./scripts/uninstall "{{target}}"
+
+# uninstalls the library from the "@local" prefix
+uninstall: (remove "@local")
+
+# uninstalls the library from the "@preview" prefix (for pre-release testing)
+uninstall-preview: (remove "@preview")
+
 # run ci suite
 ci: test doc

--- a/Justfile
+++ b/Justfile
@@ -18,5 +18,15 @@ test *args:
 update *args:
 	typst-test update {{ args }}
 
+# package the library into the specified destination folder
+package target:
+  ./scripts/package "{{target}}"
+
+# install the library with the "@local" prefix
+install: (package "@local")
+
+# install the library with the "@preview" prefix (for pre-release testing)
+install-preview: (package "@preview")
+
 # run ci suite
 ci: test doc

--- a/scripts/package
+++ b/scripts/package
@@ -4,15 +4,50 @@ set -eu
 # adapted from https://github.com/johannes-wolf/cetz/blob/35c0868378cea5ad323cc0d9c2f76de8ed9ba5bd/scripts/package
 # licensed under Apache License 2.0
 
+# ignore rules
+readarray -t ignores < <(grep -v '^#' .typstignore | grep '[^[:blank:]]')
+
+# recursively print all files that are not excluded via .typstignore
+function enumerate {
+	local root="$1"
+	if [[ -f "$root" ]]; then
+		echo "$root"
+	else
+		local files
+		readarray -t files < <(find "$root" \
+      -mindepth 1 -maxdepth 1 \
+      -not -name .git \
+      -not -name .typstignore)
+		# declare -p files >&2
+
+		local f
+		for f in "${files[@]}"; do
+			local include
+			include=1
+
+			local ignore
+			for ignore in "${ignores[@]}"; do
+				if [[ "$ignore" =~ ^! ]]; then
+					ignore="${ignore:1}"
+					if [[ "$f" == ./$ignore ]]; then
+						# echo "\"$f\" matched \"!$ignore\"" >&2
+						include=1
+					fi
+				elif [[ "$f" == ./$ignore ]]; then
+					# echo "\"$f\" matched \"$ignore\"" >&2
+					include=0
+				fi
+			done
+			if [[ "$include" == 1 ]]; then
+				enumerate "$f"
+			fi
+		done
+	fi
+}
+
 # List of all files that get packaged
-files=(
-  docs/manual.pdf
-  src/
-  CHANGELOG.md
-  LICENSE
-  README.md
-  typst.toml
-)
+readarray -t files < <(enumerate ".")
+# declare -p files >&2
 
 # Local package directories per platform
 if [[ "$OSTYPE" == "linux"* ]]; then
@@ -60,10 +95,8 @@ fi
 TMP="$(mktemp -d)"
 
 for f in "${files[@]}"; do
-  if [[ -e "$f" ]]; then
-    mkdir -p "$TMP/$(dirname "$f")" 2>/dev/null
-    cp -r "$ROOT/$f" "$TMP/$f"
-  fi
+  mkdir -p "$TMP/$(dirname "$f")" 2>/dev/null
+  cp -r "$ROOT/$f" "$TMP/$f"
 done
 
 TARGET="${TARGET:?}/${PKG_PREFIX:?}/${VERSION:?}"

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -eu
+
+# adapted from https://github.com/johannes-wolf/cetz/blob/35c0868378cea5ad323cc0d9c2f76de8ed9ba5bd/scripts/package
+# licensed under Apache License 2.0
+
+# List of all files that get packaged
+files=(
+  docs/manual.pdf
+  src/
+  CHANGELOG.md
+  LICENSE
+  README.md
+  typst.toml
+)
+
+# Local package directories per platform
+if [[ "$OSTYPE" == "linux"* ]]; then
+  DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  DATA_DIR="$HOME/Library/Application Support"
+else
+  DATA_DIR="${APPDATA}"
+fi
+
+if (( $# < 1 )) || [[ "${1:-}" == "help" ]]; then
+  echo "package TARGET"
+  echo ""
+  echo "Packages all relevant files into a directory named '<name>/<version>'"
+  echo "at TARGET. If TARGET is set to @local or @preview, the local Typst package"
+  echo "directory will be used so that the package gets installed for local use."
+  echo "The name and version are read from 'typst.toml' in the project root."
+  echo ""
+  echo "Local package prefix: $DATA_DIR/typst/package/local"
+  echo "Local preview package prefix: $DATA_DIR/typst/package/preview"
+  exit 1
+fi
+
+function read-toml() {
+  local file="$1"
+  local key="$2"
+  # Read a key value pair in the format: <key> = "<value>"
+  # stripping surrounding quotes.
+  perl -lne "print \"\$1\" if /^${key}\\s*=\\s*\"(.*)\"/" < "$file"
+}
+
+ROOT="$(cd "$(dirname "$0")"; pwd -P)/.." # macOS has no realpath
+TARGET="${1:?Missing target path, @local or @preview}"
+PKG_PREFIX="$(read-toml "$ROOT/typst.toml" "name")"
+VERSION="$(read-toml "$ROOT/typst.toml" "version")"
+
+if [[ "$TARGET" == "@local" ]]; then
+  TARGET="${DATA_DIR}/typst/packages/local"
+  echo "Install dir: $TARGET"
+elif [[ "$TARGET" == "@preview" ]]; then
+  TARGET="${DATA_DIR}/typst/packages/preview"
+  echo "Install dir: $TARGET"
+fi
+
+TMP="$(mktemp -d)"
+
+for f in "${files[@]}"; do
+  if [[ -e "$f" ]]; then
+    mkdir -p "$TMP/$(dirname "$f")" 2>/dev/null
+    cp -r "$ROOT/$f" "$TMP/$f"
+  fi
+done
+
+TARGET="${TARGET:?}/${PKG_PREFIX:?}/${VERSION:?}"
+echo "Packaged to: $TARGET"
+if rm -r "${TARGET:?}" 2>/dev/null; then
+  echo "Overwriting existing version."
+fi
+mkdir -p "$TARGET"
+mv "$TMP"/* "$TARGET"

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -eu
+
+# adapted from https://github.com/johannes-wolf/cetz/blob/35c0868378cea5ad323cc0d9c2f76de8ed9ba5bd/scripts/package
+# licensed under Apache License 2.0
+
+# Local package directories per platform
+if [[ "$OSTYPE" == "linux"* ]]; then
+  DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  DATA_DIR="$HOME/Library/Application Support"
+else
+  DATA_DIR="${APPDATA}"
+fi
+
+if (( $# < 1 )) || [[ "${1:-}" == "help" ]]; then
+  echo "uninstall TARGET"
+  echo ""
+  echo "removes the package installed into a directory named '<name>/<version>'"
+  echo "at TARGET. If TARGET is set to @local or @preview, the local Typst package"
+  echo "directory will be used so that the package gets installed for local use."
+  echo "The name and version are read from 'typst.toml' in the project root."
+  echo ""
+  echo "Local package prefix: $DATA_DIR/typst/package/local"
+  echo "Local preview package prefix: $DATA_DIR/typst/package/preview"
+  exit 1
+fi
+
+function read-toml() {
+  local file="$1"
+  local key="$2"
+  # Read a key value pair in the format: <key> = "<value>"
+  # stripping surrounding quotes.
+  perl -lne "print \"\$1\" if /^${key}\\s*=\\s*\"(.*)\"/" < "$file"
+}
+
+ROOT="$(cd "$(dirname "$0")"; pwd -P)/.." # macOS has no realpath
+TARGET="${1:?Missing target path, @local or @preview}"
+PKG_PREFIX="$(read-toml "$ROOT/typst.toml" "name")"
+VERSION="$(read-toml "$ROOT/typst.toml" "version")"
+
+if [[ "$TARGET" == "@local" ]]; then
+  TARGET="${DATA_DIR}/typst/packages/local/"
+  echo "Install dir: $TARGET"
+elif [[ "$TARGET" == "@preview" ]]; then
+  TARGET="${DATA_DIR}/typst/packages/preview/"
+  echo "Install dir: $TARGET"
+fi
+
+TARGET="${TARGET:?}/${PKG_PREFIX:?}/${VERSION:?}"
+echo "Package to uninstall: $TARGET"
+if [[ ! -e "${TARGET:?}" ]]; then
+  echo "Package was not found."
+elif rm -r "${TARGET:?}" 2>/dev/null; then
+  echo "Successfully removed."
+else
+  echo "Removal failed."
+fi


### PR DESCRIPTION
This PR adds two scripts adapted from CeTZ (Apache 2.0): https://github.com/johannes-wolf/cetz/blob/35c0868378cea5ad323cc0d9c2f76de8ed9ba5bd/scripts/package

```
# copies a selected set of files into the `out` directory
just package out

# locally installs under the name `@local/package`
just install
just uninstall

# locally installs under the name `@preview/package` (i.e. lets you test code that contains imports of the published package)
just install-preview
just uninstall-preview
```

The files that are included in packaging are those that are either necessary for the package, or are likely to be linked in the README, meaning links to them on Universe should work:
- `src/`
- `typst.toml`
- `README.md`
- `LICENSE`
- `docs/manual.pdf`
- `CHANGELOG.md`