### PR TITLE
Improve CI workflow with Typst version matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,11 @@ jobs:
       matrix:
         # add any other Typst versions that your package should support
         typst-version: ["0.11"]
+        # the docs don't need to build with all versions supported by the package;
+        # the latest one is enough
+        include:
+          - typst-version: "0.11"
+            doc: 1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,4 +50,8 @@ jobs:
           typst-version: ${{ matrix.typst-version }}
 
       - name: Run test suite
-        run: just ci
+        run: just test
+
+      - name: Build docs
+        if: ${{ matrix.doc }}
+        run: just doc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,35 +10,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Probe runner package cache
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: imagemagick cargo
           version: 1.0
 
       - name: Install oxipng from crates.io
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: oxipng
 
       - name: Install just from crates.io
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: just
 
       - name: Install typst-test from github
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: typst-test
           git: https://github.com/tingerrr/typst-test.git
           tag: ci-semi-stable
 
       - name: Setup typst
-        uses: yusancky/setup-typst@v2
+        uses: typst-community/setup-typst@v3
         with:
-          version: 'v0.11.0'
+          typst-version: '0.11'
 
       - name: Run test suite
         run: just ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   tests:
+    strategy:
+      matrix:
+        # add any other Typst versions that your package should support
+        typst-version: ["0.11"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,7 +42,7 @@ jobs:
       - name: Setup typst
         uses: typst-community/setup-typst@v3
         with:
-          typst-version: '0.11'
+          typst-version: ${{ matrix.typst-version }}
 
       - name: Run test suite
         run: just ci


### PR DESCRIPTION
This PR updates the actions used by the template's GH Actions workflow. In addition, it uses a version matrix to run tests on multiple Typst versions. The docs are still built as part of the test workflow to make sure it builds, but this is only done on the latest version (or whichever is specified) because the package can be compatible with a specific Typst version even if the docs are not.