### PR TITLE
fix package script to include hidden files (unless ignored)

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -105,4 +105,7 @@ if rm -r "${TARGET:?}" 2>/dev/null; then
   echo "Overwriting existing version."
 fi
 mkdir -p "$TARGET"
+
+# include hidden files by setting dotglob
+shopt -s dotglob
 mv "$TMP"/* "$TARGET"


### PR DESCRIPTION
using `*` to move all files in a directory is faulty because `*` does not enumerate hidden files. use `shopt -s dotglob` to fix this