### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Package and push to registry repo
+on:
+  push:
+    tags: [ v* ]
+
+env:
+  # the repository to which to push the release version
+  # usually a fork of typst/packages (https://github.com/typst/packages/)
+  # that you have push privileges to
+  REGISTRY_REPO: author/typst-packages
+  # the path within that repo where the "<name>/<version>" directory should be put
+  # for the Typst package registry, keep this as is
+  PATH_PREFIX: packages/preview
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Probe runner package cache
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: cargo
+          version: 1.0
+
+      - name: Install just from crates.io
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: just
+
+      - name: Setup typst
+        uses: typst-community/setup-typst@v3
+        with:
+          typst-version: latest
+
+      - name: Determine and check package metadata
+        run: |
+          . scripts/setup
+          echo "PKG_NAME=${PKG_PREFIX}" >> "${GITHUB_ENV}"
+          echo "PKG_VERSION=${VERSION}" >> "${GITHUB_ENV}"
+
+          if [[ "${GITHUB_REF_NAME}" != "v${VERSION}" ]]; then
+            echo "package version ${VERSION} does not match release tag ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+      - name: Build package
+        run: |
+          just doc
+          just package out
+
+      - name: Checkout package registry
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.REGISTRY_REPO }}
+          token: ${{ secrets.REGISTRY_TOKEN }}
+          path: typst-packages
+
+      - name: Release package
+        run: |
+          mkdir -p "typst-packages/${{ env.PATH_PREFIX }}/$PKG_NAME"
+          mv "out/${PKG_NAME}/${PKG_VERSION}" "typst-packages/${{ env.PATH_PREFIX }}/${PKG_NAME}"
+          rmdir "out/${PKG_NAME}"
+          rmdir out
+
+          GIT_USER_NAME="$(git log -1 --pretty=format:'%an')"
+          GIT_USER_EMAIL="$(git log -1 --pretty=format:'%ae')"
+
+          cd typst-packages
+          git config user.name "${GIT_USER_NAME}"
+          git config user.email "${GIT_USER_EMAIL}"
+          git checkout -b "${PKG_NAME}-${PKG_VERSION}"
+          git add .
+          git commit -m "${PKG_NAME}:${PKG_VERSION}"
+          git push --set-upstream origin "${PKG_NAME}-${PKG_VERSION}"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ A short description about the project and/or client.
   - See also the [typst/packages README](https://github.com/typst/packages/?tab=readme-ov-file#package-format)
 - [ ] Adapt Repository URLs in `CHANGELOG.md`
   - Consider only committing that file with your first release, or removing the "Initial Release" part in the beginning
+- [ ] Adapt or deactivate the release workflow in `.github/workflows/release.yml`
+  - to deactivate it, delete that file or remove/comment out lines 2-4 (`on:` and following)
+  - to use the workflow
+    - [ ] check the values under `env:`, particularly `REGISTRY_REPO`
+    - [ ] if you don't have one, [create a fine-grained personal access token](https://github.com/settings/tokens?type=beta) with [only Contents permission](https://stackoverflow.com/a/75116350/371191) for the `REGISTRY_REPO`
+    - [ ] on this repo, create a secret `REGISTRY_TOKEN` (at `https://github.com/[user]/[repo]/settings/secrets/actions`) that contains the so created token
+
+    if configured correctly, whenever you create a tag `v...`, your package will be pushed onto a branch on the `REGISTRY_REPO`, from which you can then create a pull request against [typst/packages](https://github.com/typst/packages/)
 - [ ] remove/replace the example test case
 - [ ] (add your actual code, docs and tests)
 - [ ] remove this section from the README

--- a/scripts/package
+++ b/scripts/package
@@ -4,6 +4,24 @@ set -eu
 # adapted from https://github.com/johannes-wolf/cetz/blob/35c0868378cea5ad323cc0d9c2f76de8ed9ba5bd/scripts/package
 # licensed under Apache License 2.0
 
+. "$(dirname "${BASH_SOURCE[0]}")/setup"
+
+if (( $# < 1 )) || [[ "${1:-}" == "help" ]]; then
+  echo "package TARGET"
+  echo ""
+  echo "Packages all relevant files into a directory named '<name>/<version>'"
+  echo "at TARGET. If TARGET is set to @local or @preview, the local Typst package"
+  echo "directory will be used so that the package gets installed for local use."
+  echo "The name and version are read from 'typst.toml' in the project root."
+  echo ""
+  echo "Local package prefix: $DATA_DIR/typst/package/local"
+  echo "Local preview package prefix: $DATA_DIR/typst/package/preview"
+  exit 1
+fi
+
+TARGET="$(resolve-target "${1:?Missing target path, @local or @preview}")"
+echo "Install dir: $TARGET"
+
 # ignore rules
 readarray -t ignores < <(grep -v '^#' .typstignore | grep '[^[:blank:]]')
 
@@ -48,49 +66,6 @@ function enumerate {
 # List of all files that get packaged
 readarray -t files < <(enumerate ".")
 # declare -p files >&2
-
-# Local package directories per platform
-if [[ "$OSTYPE" == "linux"* ]]; then
-  DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  DATA_DIR="$HOME/Library/Application Support"
-else
-  DATA_DIR="${APPDATA}"
-fi
-
-if (( $# < 1 )) || [[ "${1:-}" == "help" ]]; then
-  echo "package TARGET"
-  echo ""
-  echo "Packages all relevant files into a directory named '<name>/<version>'"
-  echo "at TARGET. If TARGET is set to @local or @preview, the local Typst package"
-  echo "directory will be used so that the package gets installed for local use."
-  echo "The name and version are read from 'typst.toml' in the project root."
-  echo ""
-  echo "Local package prefix: $DATA_DIR/typst/package/local"
-  echo "Local preview package prefix: $DATA_DIR/typst/package/preview"
-  exit 1
-fi
-
-function read-toml() {
-  local file="$1"
-  local key="$2"
-  # Read a key value pair in the format: <key> = "<value>"
-  # stripping surrounding quotes.
-  perl -lne "print \"\$1\" if /^${key}\\s*=\\s*\"(.*)\"/" < "$file"
-}
-
-ROOT="$(cd "$(dirname "$0")"; pwd -P)/.." # macOS has no realpath
-TARGET="${1:?Missing target path, @local or @preview}"
-PKG_PREFIX="$(read-toml "$ROOT/typst.toml" "name")"
-VERSION="$(read-toml "$ROOT/typst.toml" "version")"
-
-if [[ "$TARGET" == "@local" ]]; then
-  TARGET="${DATA_DIR}/typst/packages/local"
-  echo "Install dir: $TARGET"
-elif [[ "$TARGET" == "@preview" ]]; then
-  TARGET="${DATA_DIR}/typst/packages/preview"
-  echo "Install dir: $TARGET"
-fi
 
 TMP="$(mktemp -d)"
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,37 @@
+# source this script to prepare some common environment variables
+
+# adapted from https://github.com/johannes-wolf/cetz/blob/35c0868378cea5ad323cc0d9c2f76de8ed9ba5bd/scripts/package
+# licensed under Apache License 2.0
+
+# Local package directories per platform
+if [[ "$OSTYPE" == "linux"* ]]; then
+  DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  DATA_DIR="$HOME/Library/Application Support"
+else
+  DATA_DIR="${APPDATA}"
+fi
+
+function read-toml() {
+  local file="$1"
+  local key="$2"
+  # Read a key value pair in the format: <key> = "<value>"
+  # stripping surrounding quotes.
+  perl -lne "print \"\$1\" if /^${key}\\s*=\\s*\"(.*)\"/" < "$file"
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)/.." # macOS has no realpath
+PKG_PREFIX="$(read-toml "$ROOT/typst.toml" "name")"
+VERSION="$(read-toml "$ROOT/typst.toml" "version")"
+
+function resolve-target() {
+  local target="$1"
+
+	if [[ "$target" == "@local" ]]; then
+		echo "${DATA_DIR}/typst/packages/local"
+	elif [[ "$target" == "@preview" ]]; then
+		echo "${DATA_DIR}/typst/packages/preview"
+	else
+		echo "$target"
+	fi
+}

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -4,19 +4,12 @@ set -eu
 # adapted from https://github.com/johannes-wolf/cetz/blob/35c0868378cea5ad323cc0d9c2f76de8ed9ba5bd/scripts/package
 # licensed under Apache License 2.0
 
-# Local package directories per platform
-if [[ "$OSTYPE" == "linux"* ]]; then
-  DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  DATA_DIR="$HOME/Library/Application Support"
-else
-  DATA_DIR="${APPDATA}"
-fi
+. "$(dirname "${BASH_SOURCE[0]}")/setup"
 
 if (( $# < 1 )) || [[ "${1:-}" == "help" ]]; then
   echo "uninstall TARGET"
   echo ""
-  echo "removes the package installed into a directory named '<name>/<version>'"
+  echo "Removes the package installed into a directory named '<name>/<version>'"
   echo "at TARGET. If TARGET is set to @local or @preview, the local Typst package"
   echo "directory will be used so that the package gets installed for local use."
   echo "The name and version are read from 'typst.toml' in the project root."
@@ -26,26 +19,8 @@ if (( $# < 1 )) || [[ "${1:-}" == "help" ]]; then
   exit 1
 fi
 
-function read-toml() {
-  local file="$1"
-  local key="$2"
-  # Read a key value pair in the format: <key> = "<value>"
-  # stripping surrounding quotes.
-  perl -lne "print \"\$1\" if /^${key}\\s*=\\s*\"(.*)\"/" < "$file"
-}
-
-ROOT="$(cd "$(dirname "$0")"; pwd -P)/.." # macOS has no realpath
-TARGET="${1:?Missing target path, @local or @preview}"
-PKG_PREFIX="$(read-toml "$ROOT/typst.toml" "name")"
-VERSION="$(read-toml "$ROOT/typst.toml" "version")"
-
-if [[ "$TARGET" == "@local" ]]; then
-  TARGET="${DATA_DIR}/typst/packages/local/"
-  echo "Install dir: $TARGET"
-elif [[ "$TARGET" == "@preview" ]]; then
-  TARGET="${DATA_DIR}/typst/packages/preview/"
-  echo "Install dir: $TARGET"
-fi
+TARGET="$(resolve-target "${1:?Missing target path, @local or @preview}")"
+echo "Install dir: $TARGET"
 
 TARGET="${TARGET:?}/${PKG_PREFIX:?}/${VERSION:?}"
 echo "Package to uninstall: $TARGET"


### PR DESCRIPTION
This adds a second GH Actions workflow that prepares a release of the package:

- the workflow runs on pushes to tags starting with `v...`
- the version number in `typst.toml` is checked to match the tag
- the package's docs are recreated and the package is bundled for universe (`just doc`, `just package`)
- a user-specified repo (should be a fork of https://github.com/typst/packages/) is checked out
- the package is added to it at the right path (`packages/preview/<package>/<version>`)
- the changes are committed and pushed to a new branch named `<package>-<version>`, using the name and email of the tagged commit

The result is that the so-created branch is ready for opening a PR against typst/packages. The workflow needs some configuration because it needs write access to the typst/packages fork (and needs to know what repo to use for that purpose); I documented that in the README, hopefully that's sufficient.

One thing I wasn't sure about is whether giving the token full write access is the best way to do this, or if there's maybe a PR or similar permission that could be used. I didn't want to try to open PRs directly against typst/packages, because I think that would necessarily circumvent that repo's PR template. Feedback on that or anything else would be appreciated.