### PR TITLE
don't exclude README and CHANGELOG (and also Justfile)

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -13,7 +13,14 @@ keywords = []
 categories = []
 disciplines = []
 compiler = ""
-exclude = ["docs"]
+exclude = [
+	".github",
+	"docs",
+	"scripts",
+	"tests",
+	".typstignore",
+	"Justfile",
+]
 
 # [template]
 # path = "template"

--- a/typst.toml
+++ b/typst.toml
@@ -13,7 +13,7 @@ keywords = []
 categories = []
 disciplines = []
 compiler = ""
-exclude = ["README.md", "CHANGELOG.md", "Justfile", "docs"]
+exclude = ["docs"]
 
 # [template]
 # path = "template"


### PR DESCRIPTION
this removes the three items from `exclude` in typst.toml. The former two should be part of the published package; the latter should not even make it into the PR to universe and thus doesn't need to be excluded.

A possible alternative point of view is that the `package` script which uses `.typstignore` should not be assumed, and thus things like `tests` and `Justfile` should be put into `exclude`. Personally, I think that even when not using that script, these things don't belong into the PR and thus putting them in `exclude` sends the wrong signal, but it's not a strong preference.

Fixes #12 