### PR TITLE
Retain all test artifacts in CI `test` action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
           path: |
             tests/**/diff/*.png
             tests/**/out/*.png
+            tests/**/ref/*.png
           retention-days: 5
 
       - name: Build docs


### PR DESCRIPTION
When testing ephemeral tests, the `ref` directory is temporary and not populated persistently.

This changes the archive action to upload all artifacts regardless of the test kind in use to ensure they are included for debugging.