### PR TITLE
Use the Typst version to namespace diffs generated by typst-test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
           tag: ci-semi-stable
 
       - name: Setup typst
+        id: setup-typst
         uses: typst-community/setup-typst@v3
         with:
           typst-version: ${{ matrix.typst-version }}
@@ -56,7 +57,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: diffs
+          name: typst-${{ steps.setup-typst.outputs.typst-version }}-diffs
           path: |
             tests/**/diff/*.png
             tests/**/out/*.png


### PR DESCRIPTION
fixes #20; see https://github.com/SillyFreak/typst-package-template/actions/runs/11192200063 for an example run of the action. Note that the tests failed due to version-specific discrepancies, but both diffs were uploaded under the names "typst-0.10.0-diffs" and "typst-0.11.1-diffs".