### PR TITLE
New `list` script listing installed libraries

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -23,8 +23,8 @@ package target:
   ./scripts/package "{{target}}"
 
 # list installed libraries
-list:
-  ./scripts/list
+list *args:
+  ./scripts/list {{ args }}
 
 # install the library with the "@local" prefix
 install: (package "@local")

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,10 @@ update *args:
 package target:
   ./scripts/package "{{target}}"
 
+# list installed libraries
+list:
+  ./scripts/list
+
 # install the library with the "@local" prefix
 install: (package "@local")
 

--- a/scripts/list
+++ b/scripts/list
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eu
+
+. "$(dirname "${BASH_SOURCE[0]}")/setup"
+
+if [[ "${1:-}" == "help" ]]; then
+  echo "list"
+  echo ""
+  echo "List installed libraries:"
+  echo "- in the DATA_DIR and the CACHE_DIR"
+  echo "- under the @local, @preview or other prefixes"
+  echo "- all their versions"
+  echo ""
+  echo "Local package prefix: $DATA_DIR/typst/package/local"
+  echo "Local preview package prefix: $DATA_DIR/typst/package/preview"
+  exit 1
+fi
+
+get_subfolders() {
+    for subfolder in $(find $1 -maxdepth 1 -mindepth 1 -type d); do
+        echo "$(basename ${subfolder})"
+    done
+}
+
+prefixes=$(get_subfolders $DATA_DIR/typst/packages/)
+if [ -z "$prefixes" ]; then
+    echo "No prefixes found in $DATA_DIR/typst/packages/"
+else
+    echo "Prefixes found:"
+    for prefix in $prefixes; do
+        echo "$prefix"
+    done
+fi

--- a/scripts/list
+++ b/scripts/list
@@ -29,7 +29,12 @@ if [ -n "$prefixes" ]; then
         libraries=$(get_subfolders $DATA_DIR/typst/packages/$prefix)
         if [ -n "$libraries" ]; then
             for library in $libraries; do
-                echo "  @$prefix/$library"
+                versions=$(get_subfolders $DATA_DIR/typst/packages/$prefix/$library)
+                if [ -n "$libraries" ]; then
+                    for version in $versions; do
+                        echo "  @$prefix/$library:$version"
+                    done
+                fi
             done
         fi
     done

--- a/scripts/list
+++ b/scripts/list
@@ -41,7 +41,9 @@ list_libraries() {
     fi
 }
 
-echo "In $CACHE_DIR/typst/packages/"
-list_libraries $CACHE_DIR/typst/packages/
+# Start with the data directory, which have precedence over the cache directory
 echo "In $DATA_DIR/typst/packages/"
 list_libraries $DATA_DIR/typst/packages/
+# Then the cache directory, used by on-demand downloads with the Typst compiler
+echo "In $CACHE_DIR/typst/packages/"
+list_libraries $CACHE_DIR/typst/packages/

--- a/scripts/list
+++ b/scripts/list
@@ -22,12 +22,15 @@ get_subfolders() {
     done
 }
 
+echo "In $DATA_DIR/typst/packages/"
 prefixes=$(get_subfolders $DATA_DIR/typst/packages/)
-if [ -z "$prefixes" ]; then
-    echo "No prefixes found in $DATA_DIR/typst/packages/"
-else
-    echo "Prefixes found:"
+if [ -n "$prefixes" ]; then
     for prefix in $prefixes; do
-        echo "$prefix"
+        libraries=$(get_subfolders $DATA_DIR/typst/packages/$prefix)
+        if [ -n "$libraries" ]; then
+            for library in $libraries; do
+                echo "  @$prefix/$library"
+            done
+        fi
     done
 fi

--- a/scripts/list
+++ b/scripts/list
@@ -32,7 +32,7 @@ list_libraries() {
                     versions=$(get_subfolders $1/$prefix/$library)
                     if [ -n "$libraries" ]; then
                         for version in $versions; do
-                            echo "  @$prefix/$library:$version"
+                            echo -e "  \e]8;;file://$1/$prefix/$library/$version/\e\\@$prefix/$library:$version\e]8;;\e\\"
                         done
                     fi
                 done

--- a/scripts/list
+++ b/scripts/list
@@ -8,11 +8,11 @@ if [[ "${1:-}" == "help" ]]; then
   echo ""
   echo "List installed libraries:"
   echo "- in the DATA_DIR and the CACHE_DIR"
-  echo "- under the @local, @preview or other prefixes"
+  echo "- under the @local, @preview or other namespaces"
   echo "- all their versions"
   echo ""
-  echo "Local package prefix: $DATA_DIR/typst/package/local"
-  echo "Local preview package prefix: $DATA_DIR/typst/package/preview"
+  echo "Libraries in DATA_DIR: $DATA_DIR/typst/package/<namespace>/<library>/<version>/"
+  echo "Libraries in CACHE_DIR: $CACHE_DIR/typst/package/<namespace>/<library>/<version>/"
   exit 1
 fi
 
@@ -23,16 +23,16 @@ get_subfolders() {
 }
 
 list_libraries() {
-  prefixes=$(get_subfolders $1)
-  if [ -n "$prefixes" ]; then
-    for prefix in $prefixes; do
-      libraries=$(get_subfolders $1/$prefix)
+  namespaces=$(get_subfolders $1)
+  if [ -n "$namespaces" ]; then
+    for namespace in $namespaces; do
+      libraries=$(get_subfolders $1/$namespace)
       if [ -n "$libraries" ]; then
         for library in $libraries; do
-          versions=$(get_subfolders $1/$prefix/$library)
+          versions=$(get_subfolders $1/$namespace/$library)
           if [ -n "$libraries" ]; then
             for version in $versions; do
-              echo -e "  \e]8;;file://$1/$prefix/$library/$version/\e\\@$prefix/$library:$version\e]8;;\e\\"
+              echo -e "  \e]8;;file://$1/$namespace/$library/$version/\e\\@$namespace/$library:$version\e]8;;\e\\"
             done
           fi
         done

--- a/scripts/list
+++ b/scripts/list
@@ -17,28 +17,28 @@ if [[ "${1:-}" == "help" ]]; then
 fi
 
 get_subfolders() {
-    for subfolder in $(find $1 -maxdepth 1 -mindepth 1 -type d); do
-        echo "$(basename ${subfolder})"
-    done
+  for subfolder in $(find $1 -maxdepth 1 -mindepth 1 -type d); do
+    echo "$(basename ${subfolder})"
+  done
 }
 
 list_libraries() {
-    prefixes=$(get_subfolders $1)
-    if [ -n "$prefixes" ]; then
-        for prefix in $prefixes; do
-            libraries=$(get_subfolders $1/$prefix)
-            if [ -n "$libraries" ]; then
-                for library in $libraries; do
-                    versions=$(get_subfolders $1/$prefix/$library)
-                    if [ -n "$libraries" ]; then
-                        for version in $versions; do
-                            echo -e "  \e]8;;file://$1/$prefix/$library/$version/\e\\@$prefix/$library:$version\e]8;;\e\\"
-                        done
-                    fi
-                done
-            fi
+  prefixes=$(get_subfolders $1)
+  if [ -n "$prefixes" ]; then
+    for prefix in $prefixes; do
+      libraries=$(get_subfolders $1/$prefix)
+      if [ -n "$libraries" ]; then
+        for library in $libraries; do
+          versions=$(get_subfolders $1/$prefix/$library)
+          if [ -n "$libraries" ]; then
+            for version in $versions; do
+              echo -e "  \e]8;;file://$1/$prefix/$library/$version/\e\\@$prefix/$library:$version\e]8;;\e\\"
+            done
+          fi
         done
-    fi
+      fi
+    done
+  fi
 }
 
 # Start with the data directory, which have precedence over the cache directory

--- a/scripts/list
+++ b/scripts/list
@@ -16,22 +16,25 @@ if [[ "${1:-}" == "help" ]]; then
   exit 1
 fi
 
+# Returns the name of all folders inside $1
 get_subfolders() {
   for subfolder in $(find $1 -maxdepth 1 -mindepth 1 -type d); do
     echo "$(basename ${subfolder})"
   done
 }
 
+# Prints found Typst libraries in $1
 list_libraries() {
-  namespaces=$(get_subfolders $1)
-  if [ -n "$namespaces" ]; then
+  namespaces=$(get_subfolders $1) # get all namespaces
+  if [ -n "$namespaces" ]; then # if namespaces not empty
     for namespace in $namespaces; do
-      libraries=$(get_subfolders $1/$namespace)
-      if [ -n "$libraries" ]; then
+      libraries=$(get_subfolders $1/$namespace) # get all libraries under this namespace
+      if [ -n "$libraries" ]; then # if libraries not empty
         for library in $libraries; do
-          versions=$(get_subfolders $1/$namespace/$library)
-          if [ -n "$libraries" ]; then
+          versions=$(get_subfolders $1/$namespace/$library) # get all versions of this library
+          if [ -n "$libraries" ]; then # if versions not empty
             for version in $versions; do
+              # print "  @<namespace>/<library>:<version>" with a hyperlink
               echo -e "  \e]8;;file://$1/$namespace/$library/$version/\e\\@$namespace/$library:$version\e]8;;\e\\"
             done
           fi
@@ -44,6 +47,7 @@ list_libraries() {
 # Start with the data directory, which have precedence over the cache directory
 echo "In $DATA_DIR/typst/packages/"
 list_libraries $DATA_DIR/typst/packages/
+
 # Then the cache directory, used by on-demand downloads with the Typst compiler
 echo "In $CACHE_DIR/typst/packages/"
 list_libraries $CACHE_DIR/typst/packages/

--- a/scripts/list
+++ b/scripts/list
@@ -22,20 +22,26 @@ get_subfolders() {
     done
 }
 
+list_libraries() {
+    prefixes=$(get_subfolders $1)
+    if [ -n "$prefixes" ]; then
+        for prefix in $prefixes; do
+            libraries=$(get_subfolders $1/$prefix)
+            if [ -n "$libraries" ]; then
+                for library in $libraries; do
+                    versions=$(get_subfolders $1/$prefix/$library)
+                    if [ -n "$libraries" ]; then
+                        for version in $versions; do
+                            echo "  @$prefix/$library:$version"
+                        done
+                    fi
+                done
+            fi
+        done
+    fi
+}
+
+echo "In $CACHE_DIR/typst/packages/"
+list_libraries $CACHE_DIR/typst/packages/
 echo "In $DATA_DIR/typst/packages/"
-prefixes=$(get_subfolders $DATA_DIR/typst/packages/)
-if [ -n "$prefixes" ]; then
-    for prefix in $prefixes; do
-        libraries=$(get_subfolders $DATA_DIR/typst/packages/$prefix)
-        if [ -n "$libraries" ]; then
-            for library in $libraries; do
-                versions=$(get_subfolders $DATA_DIR/typst/packages/$prefix/$library)
-                if [ -n "$libraries" ]; then
-                    for version in $versions; do
-                        echo "  @$prefix/$library:$version"
-                    done
-                fi
-            done
-        fi
-    done
-fi
+list_libraries $DATA_DIR/typst/packages/

--- a/scripts/setup
+++ b/scripts/setup
@@ -12,6 +12,16 @@ else
   DATA_DIR="${APPDATA}"
 fi
 
+# Cache package directories per platform
+# See https://github.com/typst/packages?tab=readme-ov-file#downloads
+if [[ "$OSTYPE" == "linux"* ]]; then
+  CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  CACHE_DIR="$HOME/Library/Caches"
+else
+  CACHE_DIR="${LOCALAPPDATA}"
+fi
+
 function read-toml() {
   local file="$1"
   local key="$2"

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,6 +4,7 @@
 # licensed under Apache License 2.0
 
 # Local package directories per platform
+# See https://github.com/typst/packages/?tab=readme-ov-file#local-packages
 if [[ "$OSTYPE" == "linux"* ]]; then
   DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
While tweaking my `.typstignore`, I found myself often checking the content of `DATA_DIR` to be sure only the minimum was installed. So I thought about a simple `list` script parsing libraries in `DATA_DIR` and `CACHE_DIR`, printing something like `@local/my-package:0.2.1` for each:

```
❯ just list
./scripts/list 
In /home/seb/.local/share/typst/packages/
  @local/dummy:0.1.0
  @local/dummy:0.2.0
  @preview/dummy:0.2.0
  @preview/paris-saclay-thesis-flat:1.0.2
  @preview/paris-saclay-thesis-flat:1.0.1
In /home/seb/.cache/typst/packages/
  @preview/colorful-boxes:1.4.1
  @preview/oxifmt:0.2.0
  @preview/showybox:2.0.3
  @preview/lovelace:0.3.0
  @preview/ctheorems:1.1.2
  @preview/fletcher:0.5.3
  @preview/cetz:0.3.1
  @preview/charged-ieee:0.1.3
```

The hyperlinks allow, with compatible terminals, to quickly open the default file explorer there:

![Capture d’écran du 2025-02-03 14-21-23](https://github.com/user-attachments/assets/fd3d97c9-0c5d-4576-83cb-3ec99b4d0949)



