### PR TITLE
Adhere to Keep a Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,31 @@
-# [unreleased](https://github.com/<author>/<my-package>/releases/tag/<the-tag>)
-## Added
+# Changelog
 
-## Removed
+All notable changes to this project will be documented in this file.
 
-## Changed
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Migration Guide from v0.1.X
+## [Unreleased]
 
----
+<details>
+<summary>Migration guide from v0.1.X</summary>
 
-# [v0.1.0](https://github.com/<author>/<my-package>/releases/tag/v0.1.0)
+<!-- Write migration guide here -->
+
+</details>
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [[0.1.0](https://github.com/<author>/<my-package>/releases/tag/v0.1.0)] - 2025-01-01
+
 Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [[0.1.0](https://github.com/<author>/<my-package>/releases/tag/v0.1.0)] - 2025-01-01
+## [0.1.0] - 2025-01-01
 
-Initial Release
+### Added
+
+<!-- Describe the feature set of the initial release here -->
+- 
+- 
+- 
+
+<!--
+    Below are the target URLs for each version
+    You can link version numbers (in level-2 headings)
+    to the corresponding tag on GitHub, or the diff
+    in comparison to the previous release
+-->
+
+[Unreleased]: https://github.com/<author>/<my-package>/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/<author>/<my-package>/releases/tag/v0.1.0


### PR DESCRIPTION
This PR is a suggestion to follow the [Keep a Changelog](https://keepachangelog.com) initiative, for a more standardized `CHANGELOG.md`.

The motivation and choices are best described in the website, but here are some key points:
- the release date of each version is displayed
- if we follow Semantic Versioning, it is explicitly mentioned
- h1 is "Changelog", h2 are version numbers, h3 are types of changes
- h2 are formatted as `## [0.1.0] - 2025-01-01` (unambiguous date format)
- types of changes are `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed` and `Security`

![Capture d’écran du 2025-02-03 14-34-52](https://github.com/user-attachments/assets/863bec8c-6667-406f-aa20-1f7987d403ae)

The current `CHANGELOG.md` is very close to what Keep a Changelog suggests.

I kept the Migration Guide section as a collapsed section, and I kept the hyperlink to the tags on github.com.