### PR TITLE
fix typo, comment out minimum compiler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These instructions will get you a copy of the project up and running on the typs
 
 ### Installation
 
-A step by step guide that will tell you how to get the development environment up and running. This should example how to clone the repo and where to (maybe a link to the typst documentation on it), along with any pre-requisite software and installation steps.
+A step by step guide that will tell you how to get the development environment up and running. This should explain how to clone the repo and where to (maybe a link to the typst documentation on it), along with any pre-requisite software and installation steps.
 
 ```
 $ First step

--- a/typst.toml
+++ b/typst.toml
@@ -12,7 +12,7 @@ repository = ""
 keywords = []
 categories = []
 disciplines = []
-compiler = ""
+# compiler = ""
 exclude = [
 	".github",
 	"docs",


### PR DESCRIPTION
A wrong word; and having `compiler = ""` in the manifest lets typst and tytanic error on certain commands since it is not valid. Alternatively the version could be set to e.g. `"0.12.0"`, but that could lead to packages not checking that that is the actual minimum version, and then containing a wrong value. I think excluding this is thus preferable.