### PR TITLE
use install-action instead of cargo install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Probe runner package cache
-        uses: awalsh128/cache-apt-pkgs-action@v1
+      - name: Install just
+        uses: taiki-e/install-action@v2
         with:
-          packages: cargo
-          version: 1.0
-
-      - name: Install just from crates.io
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: just
+          tool: just
 
       - name: Setup typst
         uses: typst-community/setup-typst@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,22 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Probe runner package cache
-        uses: awalsh128/cache-apt-pkgs-action@v1
+      - name: Install just and tytanic
+        uses: taiki-e/install-action@v2
         with:
-          packages: cargo
-          version: 1.0
-
-      - name: Install just from crates.io
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: just
-
-      - name: Install tytanic from crates.io
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: tytanic
-          version: ${{ matrix.typst-version.tytanic }}
+          tool: just,tytanic@${{ matrix.typst-version.tytanic }}
 
       - name: Setup typst
         id: setup-typst


### PR DESCRIPTION
this replaces installing cargo via apt and then using `cargo install` for installing just and tytanic with `taiki-e/install-action` (recommended by binstall: https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#in-github-actions).

This change makes the CI pipelines faster and using fewer resources, since it installs pre-built binaries instead of compiling these tools.