### PR TITLE
add support for testing on prereleases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
         typst-version:
           - typst: 0.12
             tytanic: 0.1
+          - typst: 0.13.0-rc1
+            tytanic: 0.2.0-rc1
           - typst: 0.13
             tytanic: 0.2
             # the docs don't need to build with all versions supported by the package;


### PR DESCRIPTION
I'm not sure if this should be merged, would be interested in others' opinions.

I think it's in general useful to have support for testing on prereleases (conditioned on both a Typst and compatible Tytanic prerelease already existing of course). However, the binstall action we use doesn't support prereleases:

> Error: install-action v2 does not support semver pre-release and build-metadata: '0.2.0-rc1'; if you need these supports again, please submit an issue at <https://github.com/taiki-e/install-action>

So this requires extra measures to use `cargo install` instead. Also, since a prerelease is not the real thing yet, should the template explicitly use them? And if not, is the infrastructure for prereleases still "appropriate" to include?

Basically the options I see are
- don't merge this
- remove 0.13.0-rc1 from the matrix, but prepare the action for installing Tytanic prereleases
- merge as-is, i.e. referencing the Typst and Tytanic prereleases (they would be replaced with the releases once they're out)

I lean towards this being useful enough for package authors to merge in one of the two ways, but would like others' take on this.